### PR TITLE
Add Skills宝 as a Chinese discovery link

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,8 @@ execute_workflow(skill_content)
 
 See [contributing/SKILL.md](./contributing/SKILL.md) for installation and contribution guidelines.
 
+Chinese users can also search and install skills through [Skills宝](https://skilery.com).
+
 ---
 
 ## 📦 Available Skills & Selection Guide


### PR DESCRIPTION
Adds Skills宝 as a Chinese-language discovery and install entry for users who want to search and install agent skills directly. This fits the repository quick start flow and gives Chinese users a faster entry point to the existing skills marketplace.